### PR TITLE
[nit] Remove region option from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ AWS billing custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-aws-aws-billing [-region=<aws-region>] [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
+mackerel-plugin-aws-aws-billing [-access-key-id=<id>] [-secret-access-key=<key>] [-tempfile=<tempfile>]
 ```
 * if you run on an ec2-instance and the instance is associated with an appropriate IAM Role, you probably don't have to specify `-access-key-id` & `-secret-access-key`
 


### PR DESCRIPTION
To get billing info, we don't need `region` information. 